### PR TITLE
Add TLSClientConfig to default http client

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/tls"
 	"fmt"
 
 	"github.com/tomnomnom/linkheader"
@@ -32,9 +33,10 @@ type ErrorDetail struct {
 
 // Config contains all the configuration data for the API Client
 type Config struct {
-	APIKey  string
-	BaseURL string
-	Debug   bool
+	APIKey    string
+	BaseURL   string
+	Debug     bool
+	TLSConfig *tls.Config
 }
 
 // New returns a new Client for the specified apiKey.
@@ -49,6 +51,9 @@ func New(config Config) Client {
 	r.SetHeader("X-Api-Key", config.APIKey)
 	r.SetHostURL(baseURL)
 
+	if config.TLSConfig != nil {
+		r.SetTLSClientConfig(config.TLSConfig)
+	}
 	if config.Debug {
 		r.SetDebug(true)
 	}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
 )
@@ -12,6 +13,22 @@ func newTestAPIClient(handler http.Handler) *Client {
 		APIKey:  "123456",
 		BaseURL: ts.URL,
 		Debug:   false,
+	})
+
+	return &c
+}
+
+func newTestAPIClientTLSConfig(handler http.Handler) *Client {
+	ts := httptest.NewServer(handler)
+
+	tlsCfg := &tls.Config{}
+	tlsCfg.InsecureSkipVerify = true
+
+	c := New(Config{
+		APIKey:    "123456",
+		BaseURL:   ts.URL,
+		Debug:     false,
+		TLSConfig: tlsCfg,
 	})
 
 	return &c


### PR DESCRIPTION
This change is to allow the configuration of a TLSClientConfig to be used on the resty requests made to the new relic api. A subsequent PR made to terraform is to follow.