### PR TITLE
Add New Relic Infrastructure API support

### DIFF
--- a/api/alert_infra_conditions.go
+++ b/api/alert_infra_conditions.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-func (i *InfraClient) queryAlertInfraConditions(policyID int) ([]AlertInfraCondition, error) {
+func (c *InfraClient) queryAlertInfraConditions(policyID int) ([]AlertInfraCondition, error) {
 	conditions := []AlertInfraCondition{}
 
 	reqURL, err := url.Parse("/alerts/conditions")
@@ -26,7 +26,7 @@ func (i *InfraClient) queryAlertInfraConditions(policyID int) ([]AlertInfraCondi
 			InfraConditions []AlertInfraCondition `json:"data,omitempty"`
 		}{}
 
-		nextPath, err = i.Do("GET", nextPath, nil, &resp)
+		nextPath, err = c.Do("GET", nextPath, nil, &resp)
 		if err != nil {
 			return nil, err
 		}
@@ -42,8 +42,8 @@ func (i *InfraClient) queryAlertInfraConditions(policyID int) ([]AlertInfraCondi
 }
 
 // GetAlertInfraCondition gets information about a Infra alert condition given an ID and policy ID.
-func (i *InfraClient) GetAlertInfraCondition(policyID int, id int) (*AlertInfraCondition, error) {
-	conditions, err := i.queryAlertInfraConditions(policyID)
+func (c *InfraClient) GetAlertInfraCondition(policyID int, id int) (*AlertInfraCondition, error) {
+	conditions, err := c.queryAlertInfraConditions(policyID)
 	if err != nil {
 		return nil, err
 	}
@@ -58,12 +58,12 @@ func (i *InfraClient) GetAlertInfraCondition(policyID int, id int) (*AlertInfraC
 }
 
 // ListAlertInfraConditions returns Infra alert conditions for the specified policy.
-func (i *InfraClient) ListAlertInfraConditions(policyID int) ([]AlertInfraCondition, error) {
-	return i.queryAlertInfraConditions(policyID)
+func (c *InfraClient) ListAlertInfraConditions(policyID int) ([]AlertInfraCondition, error) {
+	return c.queryAlertInfraConditions(policyID)
 }
 
 // CreateAlertInfraCondition creates an Infra alert condition given the passed configuration.
-func (i *InfraClient) CreateAlertInfraCondition(condition AlertInfraCondition) (*AlertInfraCondition, error) {
+func (c *InfraClient) CreateAlertInfraCondition(condition AlertInfraCondition) (*AlertInfraCondition, error) {
 	policyID := condition.PolicyID
 
 	req := struct {
@@ -77,7 +77,7 @@ func (i *InfraClient) CreateAlertInfraCondition(condition AlertInfraCondition) (
 	}{}
 
 	u := &url.URL{Path: "/alerts/conditions"}
-	_, err := i.Do("POST", u.String(), req, &resp)
+	_, err := c.Do("POST", u.String(), req, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (i *InfraClient) CreateAlertInfraCondition(condition AlertInfraCondition) (
 }
 
 // UpdateAlertInfraCondition updates an Infra alert condition with the specified changes.
-func (i *InfraClient) UpdateAlertInfraCondition(condition AlertInfraCondition) (*AlertInfraCondition, error) {
+func (c *InfraClient) UpdateAlertInfraCondition(condition AlertInfraCondition) (*AlertInfraCondition, error) {
 	policyID := condition.PolicyID
 	id := condition.ID
 
@@ -103,7 +103,7 @@ func (i *InfraClient) UpdateAlertInfraCondition(condition AlertInfraCondition) (
 	}{}
 
 	u := &url.URL{Path: fmt.Sprintf("/alerts/conditions/%v", id)}
-	_, err := i.Do("PUT", u.String(), req, &resp)
+	_, err := c.Do("PUT", u.String(), req, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -114,8 +114,8 @@ func (i *InfraClient) UpdateAlertInfraCondition(condition AlertInfraCondition) (
 }
 
 // DeleteAlertInfraCondition removes the Infra alert condition given the specified ID and policy ID.
-func (i *InfraClient) DeleteAlertInfraCondition(policyID int, id int) error {
+func (c *InfraClient) DeleteAlertInfraCondition(policyID int, id int) error {
 	u := &url.URL{Path: fmt.Sprintf("/alerts/conditions/%v", id)}
-	_, err := i.Do("DELETE", u.String(), nil, nil)
+	_, err := c.Do("DELETE", u.String(), nil, nil)
 	return err
 }

--- a/api/alert_infra_conditions.go
+++ b/api/alert_infra_conditions.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+func (i *InfraClient) queryAlertInfraConditions(policyID int) ([]AlertInfraCondition, error) {
+	conditions := []AlertInfraCondition{}
+
+	reqURL, err := url.Parse("/alerts/conditions")
+	if err != nil {
+		return nil, err
+	}
+
+	qs := reqURL.Query()
+	qs.Set("policy_id", strconv.Itoa(policyID))
+
+	reqURL.RawQuery = qs.Encode()
+
+	nextPath := reqURL.String()
+
+	for nextPath != "" {
+		resp := struct {
+			InfraConditions []AlertInfraCondition `json:"data,omitempty"`
+		}{}
+
+		nextPath, err = i.Do("GET", nextPath, nil, &resp)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, c := range resp.InfraConditions {
+			c.PolicyID = policyID
+		}
+
+		conditions = append(conditions, resp.InfraConditions...)
+	}
+
+	return conditions, nil
+}
+
+// GetAlertInfraCondition gets information about a Infra alert condition given an ID and policy ID.
+func (i *InfraClient) GetAlertInfraCondition(policyID int, id int) (*AlertInfraCondition, error) {
+	conditions, err := i.queryAlertInfraConditions(policyID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, condition := range conditions {
+		if condition.ID == id {
+			return &condition, nil
+		}
+	}
+
+	return nil, ErrNotFound
+}
+
+// ListAlertInfraConditions returns Infra alert conditions for the specified policy.
+func (i *InfraClient) ListAlertInfraConditions(policyID int) ([]AlertInfraCondition, error) {
+	return i.queryAlertInfraConditions(policyID)
+}
+
+// CreateAlertInfraCondition creates an Infra alert condition given the passed configuration.
+func (i *InfraClient) CreateAlertInfraCondition(condition AlertInfraCondition) (*AlertInfraCondition, error) {
+	policyID := condition.PolicyID
+
+	req := struct {
+		Condition AlertInfraCondition `json:"data"`
+	}{
+		Condition: condition,
+	}
+
+	resp := struct {
+		Condition AlertInfraCondition `json:"data,omitempty"`
+	}{}
+
+	u := &url.URL{Path: "/alerts/conditions"}
+	_, err := i.Do("POST", u.String(), req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	resp.Condition.PolicyID = policyID
+
+	return &resp.Condition, nil
+}
+
+// UpdateAlertInfraCondition updates an Infra alert condition with the specified changes.
+func (i *InfraClient) UpdateAlertInfraCondition(condition AlertInfraCondition) (*AlertInfraCondition, error) {
+	policyID := condition.PolicyID
+	id := condition.ID
+
+	req := struct {
+		Condition AlertInfraCondition `json:"data"`
+	}{
+		Condition: condition,
+	}
+
+	resp := struct {
+		Condition AlertInfraCondition `json:"data,omitempty"`
+	}{}
+
+	u := &url.URL{Path: fmt.Sprintf("/alerts/conditions/%v", id)}
+	_, err := i.Do("PUT", u.String(), req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	resp.Condition.PolicyID = policyID
+
+	return &resp.Condition, nil
+}
+
+// DeleteAlertInfraCondition removes the Infra alert condition given the specified ID and policy ID.
+func (i *InfraClient) DeleteAlertInfraCondition(policyID int, id int) error {
+	u := &url.URL{Path: fmt.Sprintf("/alerts/conditions/%v", id)}
+	_, err := i.Do("DELETE", u.String(), nil, nil)
+	return err
+}

--- a/api/alert_infra_conditions_test.go
+++ b/api/alert_infra_conditions_test.go
@@ -1,0 +1,264 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestQueryAlertInfraConditions(t *testing.T) {
+	c := newTestAPIInfraClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+			{
+			  "data": [
+			    {
+					"type": "infra_metric",
+					"name": "High CPU",
+					"enabled": true,
+					"id": 1013339,
+					"created_at_epoch_millis": 1521478734169,
+					"updated_at_epoch_millis": 1521478734227,
+					"policy_id": 210972,
+					"event_type": "SystemSample",
+					"select_value": "cpuPercent",
+					"comparison": "above",
+					"critical_threshold": {
+						"value": 75,
+						"duration_minutes": 2,
+						"time_function": "all"
+					}
+				}
+			  ]
+			}
+			`))
+	}))
+
+	policyID := 123
+
+	infraAlertConditions, err := c.queryAlertInfraConditions(policyID)
+	if err != nil {
+		t.Log(err)
+		t.Fatal("queryAlertInfraConditions error")
+	}
+
+	if len(infraAlertConditions) == 0 {
+		t.Fatal("No Infra Alert Conditions found")
+	}
+}
+
+func TestGetAlertInfraCondition(t *testing.T) {
+	c := newTestAPIInfraClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+			{
+				"data": [
+				  {
+					  "type": "infra_metric",
+					  "name": "High CPU",
+					  "enabled": true,
+					  "id": 12345,
+					  "created_at_epoch_millis": 1521478734169,
+					  "updated_at_epoch_millis": 1521478734227,
+					  "policy_id": 210972,
+					  "event_type": "SystemSample",
+					  "select_value": "cpuPercent",
+					  "comparison": "above",
+					  "critical_threshold": {
+						  "value": 75,
+						  "duration_minutes": 2,
+						  "time_function": "all"
+					  }
+				  }
+				]
+			}
+			`))
+	}))
+
+	policyID := 123
+	conditionID := 12345
+
+	infraAlertCondition, err := c.GetAlertInfraCondition(policyID, conditionID)
+	if err != nil {
+		t.Log(err)
+		t.Fatal("GetAlertInfraCondition error")
+	}
+	if infraAlertCondition == nil {
+		t.Log(err)
+		t.Fatal("GetAlertInfraCondition error")
+	}
+}
+
+func TestListAlertInfraConditions(t *testing.T) {
+	c := newTestAPIInfraClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+			{
+				"data": [
+				  {
+					  "type": "infra_metric",
+					  "name": "High CPU",
+					  "enabled": true,
+					  "id": 12345,
+					  "created_at_epoch_millis": 1521478734169,
+					  "updated_at_epoch_millis": 1521478734227,
+					  "policy_id": 210972,
+					  "event_type": "SystemSample",
+					  "select_value": "cpuPercent",
+					  "comparison": "above",
+					  "critical_threshold": {
+						  "value": 75,
+						  "duration_minutes": 2,
+						  "time_function": "all"
+					  }
+				  }
+				]
+			}
+			`))
+	}))
+
+	policyID := 123
+
+	infraAlertConditions, err := c.ListAlertInfraConditions(policyID)
+	if err != nil {
+		t.Log(err)
+		t.Fatal("ListAlertInfraConditions error")
+	}
+	if len(infraAlertConditions) == 0 {
+		t.Log(err)
+		t.Fatal("ListAlertInfraConditions error")
+	}
+}
+
+func TestCreateAlertInfraCondition(t *testing.T) {
+	c := newTestAPIInfraClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+			{
+				"data":{
+				   "type":"infra_metric",
+				   "name":"Disk Space Condition",
+				   "enabled":true,
+				   "policy_id":123,
+				   "id":12345,
+				   "event_type":"StorageSample",
+				   "select_value":"diskFreePercent",
+				   "comparison":"below",
+				   "warning_threshold":{
+					  "value":30,
+					  "duration_minutes":2,
+					  "time_function":"any"
+				   }
+				}
+			 }
+			`))
+	}))
+
+	infraAlertConditionWarning := AlertInfraThreshold{
+		Value:    30,
+		Duration: 100,
+		Function: "any",
+	}
+
+	infraAlertCondition := AlertInfraCondition{
+		PolicyID:   123,
+		Name:       "Disk Space Condition",
+		Enabled:    true,
+		Warning:    infraAlertConditionWarning,
+		Comparison: "below",
+		Event:      "StorageSample",
+		Select:     "diskFreePercent",
+	}
+
+	infraAlertConditionResp, err := c.CreateAlertInfraCondition(infraAlertCondition)
+	if err != nil {
+		t.Log(err)
+		t.Fatal("CreateAlertInfraCondition error")
+	}
+	if infraAlertConditionResp == nil {
+		t.Log(err)
+		t.Fatal("CreateAlertInfraCondition error")
+	}
+	if infraAlertConditionResp.ID != 12345 {
+		t.Fatal("Condition ID was not parsed correctly")
+	}
+}
+
+func TestUpdateAlertInfraCondition(t *testing.T) {
+	c := newTestAPIInfraClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+			{
+				"data":{
+				   "type":"infra_metric",
+				   "name":"Disk Space Condition",
+				   "enabled":true,
+				   "policy_id":123,
+				   "id":12345,
+				   "event_type":"StorageSample",
+				   "select_value":"diskFreePercent",
+				   "comparison":"below",
+				   "warning_threshold":{
+					  "value":30,
+					  "duration_minutes":2,
+					  "time_function":"any"
+				   }
+				}
+			 }
+			`))
+	}))
+
+	infraAlertConditionWarning := AlertInfraThreshold{
+		Value:    30,
+		Duration: 100,
+		Function: "any",
+	}
+
+	infraAlertCondition := AlertInfraCondition{
+		PolicyID:   123,
+		Name:       "Test Condition",
+		Enabled:    true,
+		Warning:    infraAlertConditionWarning,
+		Comparison: "below",
+		Event:      "StorageSample",
+		Select:     "diskFreePercent",
+	}
+
+	infraAlertConditionResp, err := c.UpdateAlertInfraCondition(infraAlertCondition)
+	if err != nil {
+		t.Log(err)
+		t.Fatal("UpdateAlertInfraCondition error")
+	}
+	if infraAlertConditionResp == nil {
+		t.Log(err)
+		t.Fatal("UpdateAlertInfraCondition error")
+	}
+	if infraAlertConditionResp.ID != 12345 {
+		t.Fatal("Condition ID was not parsed correctly")
+	}
+}
+
+func TestDeleteAlertInfraCondition(t *testing.T) {
+	policyID := 123
+	conditionID := 12345
+	c := newTestAPIInfraClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if r.Method != "DELETE" {
+			t.Fatal("DeleteAlertInfraCondition did not use DELETE method")
+		}
+		if r.URL.Path != fmt.Sprintf("/alerts/conditions/%v", conditionID) {
+			t.Fatal("DeleteAlertInfraCondition did not use the correct URL")
+		}
+	}))
+	err := c.DeleteAlertInfraCondition(policyID, conditionID)
+	if err != nil {
+		t.Log(err)
+		t.Fatal("DeleteAlertInfraCondition error")
+	}
+}

--- a/api/client.go
+++ b/api/client.go
@@ -82,7 +82,8 @@ func New(config Config) Client {
 // Do exectes an API request with the specified parameters.
 func (c *Client) Do(method string, path string, body interface{}, response interface{}) (string, error) {
 	r := c.RestyClient.R().
-		SetError(&ErrorResponse{})
+		SetError(&ErrorResponse{}).
+		SetHeader("Content-Type", "application/json")
 
 	if body != nil {
 		r = r.SetBody(body)

--- a/api/client.go
+++ b/api/client.go
@@ -14,6 +14,20 @@ type Client struct {
 	RestyClient *resty.Client
 }
 
+// InfraClient represents the client state for the Infrastructure API
+type InfraClient struct {
+	Client
+}
+
+// NewInfraClient returns a new InfraClient for the specified apiKey.
+func NewInfraClient(config Config) InfraClient {
+	if config.BaseURL == "" {
+		config.BaseURL = "https://infra-api.newrelic.com/v2"
+	}
+
+	return InfraClient{New(config)}
+}
+
 // ErrorResponse represents an error response from New Relic.
 type ErrorResponse struct {
 	Detail *ErrorDetail `json:"error,omitempty"`

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -18,6 +18,18 @@ func newTestAPIClient(handler http.Handler) *Client {
 	return &c
 }
 
+func newTestAPIInfraClient(handler http.Handler) *InfraClient {
+	ts := httptest.NewServer(handler)
+
+	c := NewInfraClient(Config{
+		APIKey:  "123456",
+		BaseURL: ts.URL,
+		Debug:   false,
+	})
+
+	return &c
+}
+
 func newTestAPIClientTLSConfig(handler http.Handler) *Client {
 	ts := httptest.NewServer(handler)
 

--- a/api/types.go
+++ b/api/types.go
@@ -297,3 +297,28 @@ type DashboardWidgetLayout struct {
 	Row    int `json:"row"`
 	Column int `json:"column"`
 }
+
+// AlertInfraThreshold represents an Infra alerting condition
+type AlertInfraThreshold struct {
+	Value    int    `json:"value,omitempty"`
+	Duration int    `json:"duration_minutes,omitempty"`
+	Function string `json:"time_function,omitempty"`
+}
+
+// AlertInfraCondition represents a New Relic Infra Alert condition.
+type AlertInfraCondition struct {
+	PolicyID     int                 `json:"policy_id,omitempty"`
+	ID           int                 `json:"id,omitempty"`
+	Name         string              `json:"name,omitempty"`
+	Type         string              `json:"type,omitempty"`
+	Comparison   string              `json:"comparison,omitempty"`
+	CreatedAt    int                 `json:"created_at_epoch_millis,omitempty"`
+	UpdatedAt    int                 `json:"updated_at_epoch_millis,omitempty"`
+	Enabled      bool                `json:"enabled,omitempty"`
+	Event        string              `json:"event_type,omitempty"`
+	Select       string              `json:"select_value,omitempty"`
+	Where        string              `json:"where_clause,omitempty"`
+	ProcessWhere string              `json:"process_where_clause,omitempty"`
+	Warning      AlertInfraThreshold `json:"warning_threshold,omitempty"`
+	Critical     AlertInfraThreshold `json:"critical_threshold,omitempty"`
+}


### PR DESCRIPTION
As requested by @smithclay in https://github.com/terraform-providers/terraform-provider-newrelic/pull/30

Let me know if this is what you had in mind. This adds New Relic Infrastructure API support.