### PR TITLE
Convert AlertInfraCondition thresholds to pointers

### DIFF
--- a/api/alert_infra_conditions_test.go
+++ b/api/alert_infra_conditions_test.go
@@ -158,7 +158,7 @@ func TestCreateAlertInfraCondition(t *testing.T) {
 			`))
 	}))
 
-	infraAlertConditionWarning := AlertInfraThreshold{
+	infraAlertConditionWarning := &AlertInfraThreshold{
 		Value:    30,
 		Duration: 100,
 		Function: "any",
@@ -213,7 +213,7 @@ func TestUpdateAlertInfraCondition(t *testing.T) {
 			`))
 	}))
 
-	infraAlertConditionWarning := AlertInfraThreshold{
+	infraAlertConditionWarning := &AlertInfraThreshold{
 		Value:    30,
 		Duration: 100,
 		Function: "any",

--- a/api/types.go
+++ b/api/types.go
@@ -307,18 +307,18 @@ type AlertInfraThreshold struct {
 
 // AlertInfraCondition represents a New Relic Infra Alert condition.
 type AlertInfraCondition struct {
-	PolicyID     int                 `json:"policy_id,omitempty"`
-	ID           int                 `json:"id,omitempty"`
-	Name         string              `json:"name,omitempty"`
-	Type         string              `json:"type,omitempty"`
-	Comparison   string              `json:"comparison,omitempty"`
-	CreatedAt    int                 `json:"created_at_epoch_millis,omitempty"`
-	UpdatedAt    int                 `json:"updated_at_epoch_millis,omitempty"`
-	Enabled      bool                `json:"enabled,omitempty"`
-	Event        string              `json:"event_type,omitempty"`
-	Select       string              `json:"select_value,omitempty"`
-	Where        string              `json:"where_clause,omitempty"`
-	ProcessWhere string              `json:"process_where_clause,omitempty"`
-	Warning      AlertInfraThreshold `json:"warning_threshold,omitempty"`
-	Critical     AlertInfraThreshold `json:"critical_threshold,omitempty"`
+	PolicyID     int                  `json:"policy_id,omitempty"`
+	ID           int                  `json:"id,omitempty"`
+	Name         string               `json:"name,omitempty"`
+	Type         string               `json:"type,omitempty"`
+	Comparison   string               `json:"comparison,omitempty"`
+	CreatedAt    int                  `json:"created_at_epoch_millis,omitempty"`
+	UpdatedAt    int                  `json:"updated_at_epoch_millis,omitempty"`
+	Enabled      bool                 `json:"enabled,omitempty"`
+	Event        string               `json:"event_type,omitempty"`
+	Select       string               `json:"select_value,omitempty"`
+	Where        string               `json:"where_clause,omitempty"`
+	ProcessWhere string               `json:"process_where_clause,omitempty"`
+	Warning      *AlertInfraThreshold `json:"warning_threshold,omitempty"`
+	Critical     *AlertInfraThreshold `json:"critical_threshold,omitempty"`
 }


### PR DESCRIPTION
Let me know if there is a better way to do this. The idea is that this makes it much easier to determine if these things aren't set in `terraform-provider-newrelic` as an optional parameter so it can be properly omitted, ie:

```go
if attr, ok := d.GetOk("warning"); ok {
	// blahblahblah
}
```

If an empty warning threshold gets sent to the API it creates an invalid Alert Condition that can no longer be described without a GET resulting in a 500.