### PR TITLE
Update created_at and updated_at to int64

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -26,8 +26,8 @@ type AlertPolicy struct {
 	ID                 int    `json:"id,omitempty"`
 	IncidentPreference string `json:"incident_preference,omitempty"`
 	Name               string `json:"name,omitempty"`
-	CreatedAt          int    `json:"created_at,omitempty"`
-	UpdatedAt          int    `json:"updated_at,omitempty"`
+	CreatedAt          int64  `json:"created_at,omitempty"`
+	UpdatedAt          int64  `json:"updated_at,omitempty"`
 }
 
 // AlertConditionUserDefined represents user defined metrics for the New Relic alert condition.


### PR DESCRIPTION
### Debug Output
```
Error: Error applying plan:
1 error(s) occurred:
* newrelic_alert_policy.example: 1 error(s) occurred:
* newrelic_alert_policy.example: json: cannot unmarshal number 1536617863733 into Go struct field AlertPolicy.created_at of type int
```

### New Relic API
https://rpm.newrelic.com/api/explore/alerts_policies/list
```json
{
  "policy": {
    "id": "integer",
    "incident_preference": "string",
    "name": "string",
    "created_at": "integer",
    "updated_at": "integer"
  }
}
```

### Problem Identified
This library expects the `int` go type for the `created_at` and `updated_at` fields in the json response from the list alert policies New Relic api (see above). These properties represent the unix timestamp (epoch time) for the corresponding values. But, rather than seconds, the New Relic api returns the values as milliseconds. The current unix timestamp is currently larger than maximum value (2147483647) of a [go `int` type](https://golang.org/pkg/builtin/#int32), so the value fails to deserialize.

### Solution
I've updated the expected type to `int64` to support the larger value.