### PR TITLE
Add opt for sequentializing policy_channel updates

### DIFF
--- a/api/alert_policy_channels.go
+++ b/api/alert_policy_channels.go
@@ -8,6 +8,16 @@ import (
 
 // UpdateAlertPolicyChannels updates a policy by adding the specified notification channels.
 func (c *Client) UpdateAlertPolicyChannels(policyID int, channelIDs []int) error {
+	if c.seqPolicyChannelUpdates {
+		/** Locks and unlocks the set of channels so that only one
+		*   update will be performed on the resource at a time.
+		*   This is to prevent a known issue with parallel requests
+		*   for updates involving the same channel.
+		**/
+		c.LockResources("channel", channelIDs)
+		defer c.UnlockResources("channel", channelIDs)
+	}
+
 	channelIDStrings := make([]string, len(channelIDs))
 
 	for i, channelID := range channelIDs {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func newTestAPIClient(handler http.Handler) *Client {
@@ -53,11 +54,12 @@ func TestLockResources(t *testing.T) {
 	c.LockResources("resource", ids)
 
 	for _, id := range ids {
-		if _, ok := c.resourceMap.Load(resourceID("resource", id)); !ok {
+		if _, ok := c.resourceMap[(resourceID("resource", id))]; !ok {
 			t.Log("Failed to lock resources")
 			t.Fail()
 		}
 	}
+
 }
 
 func TestUnLockResources(t *testing.T) {
@@ -65,15 +67,74 @@ func TestUnLockResources(t *testing.T) {
 	ids := []int{123, 456}
 
 	for _, id := range ids {
-		c.resourceMap.Store(resourceID("resource", id), struct{}{})
+		c.resourceMap[resourceID("resource", id)] = make(chan struct{}, 1)
 	}
 
 	c.UnlockResources("resource", ids)
 
 	for _, id := range ids {
-		if _, ok := c.resourceMap.Load(resourceID("resource", id)); ok {
+		select {
+		case <-c.resourceMap[resourceID("resource", id)]:
+			continue
+		default:
 			t.Log("Failed to unlock resources")
 			t.Fail()
 		}
+	}
+}
+
+func TestLockingOfResources(t *testing.T) {
+	var c = New(Config{})
+	var res123Locked bool
+	var res456Locked bool
+	var done = make(chan struct{})
+
+	f := func(id int, t *testing.T) {
+		c.LockResources("resource", []int{id})
+		defer func() {
+			// before this func f returns, set locked bool to false
+			// and actually unlock the resources
+			if id == 123 {
+				res123Locked = false
+			}
+			if id == 456 {
+				res456Locked = false
+			}
+			c.UnlockResources("resource", []int{id})
+			done <- struct{}{}
+		}()
+		if id == 123 {
+			if res123Locked {
+				// if res123 is locked, fail because we shouldn't be able
+				// to access it
+				t.Log("Resource accessed while locked")
+				t.Fail()
+			}
+			// now set the locked bool to true
+			res123Locked = true
+		}
+		if id == 456 {
+			if res456Locked {
+				// if res456 is locked, fail because we shouldn't be able
+				// to access it
+				t.Log("Resource accessed while locked")
+				t.Fail()
+			}
+			// now set the locked bool to true
+			res456Locked = true
+		}
+		// wait a little bit to ensure the goroutines overlap
+		time.Sleep(time.Second / 10)
+
+	}
+
+	for i := 0; i < 4; i++ {
+		go f(123, t)
+		go f(456, t)
+	}
+
+	// make sure all goroutines have finished before continuing
+	for i := 0; i < 8; i++ {
+		<-done
 	}
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -53,7 +53,7 @@ func TestLockResources(t *testing.T) {
 	c.LockResources("resource", ids)
 
 	for _, id := range ids {
-		if _, ok := c.m.Load(resourceID("resource", id)); !ok {
+		if _, ok := c.resourceMap.Load(resourceID("resource", id)); !ok {
 			t.Log("Failed to lock resources")
 			t.Fail()
 		}
@@ -65,13 +65,13 @@ func TestUnLockResources(t *testing.T) {
 	ids := []int{123, 456}
 
 	for _, id := range ids {
-		c.m.Store(resourceID("resource", id), struct{}{})
+		c.resourceMap.Store(resourceID("resource", id), struct{}{})
 	}
 
 	c.UnlockResources("resource", ids)
 
 	for _, id := range ids {
-		if _, ok := c.m.Load(resourceID("resource", id)); ok {
+		if _, ok := c.resourceMap.Load(resourceID("resource", id)); ok {
 			t.Log("Failed to unlock resources")
 			t.Fail()
 		}


### PR DESCRIPTION
There is a known issue of parallelized policy_channel updates failing
when separate requests try to mutate the same channel. New Relic has
confirmed this happens because an update to the policy_channel link is
actually a mutation of the channel itself which includes a list of
policies. That list is not locked, so parallelized requests stomp
down on each other, leading to errors when using infrastructure
management tools, like Terraform, that fire requests in close succession.

Related issue:
https://github.com/terraform-providers/terraform-provider-newrelic/issues/100