### PR TITLE
Add opt for sequentializing policy_channel updates

### DIFF
--- a/api/alert_policy_channels.go
+++ b/api/alert_policy_channels.go
@@ -27,6 +27,12 @@ func (c *Client) UpdateAlertPolicyChannels(policyID int, channelIDs []int) error
 
 	nextPath := reqURL.String()
 
+	if c.seqPolicyChannelUpdates {
+		// If client is configured to prevent concurrent policy_channel
+		// updates, lock this process and defer an unlocking.
+		c.mutex.Lock()
+		defer c.mutex.Unlock()
+	}
 	_, err = c.Do("PUT", nextPath, nil, nil)
 	return err
 }

--- a/api/client.go
+++ b/api/client.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/tls"
 	"fmt"
+	"sync"
 
 	"github.com/tomnomnom/linkheader"
 	resty "gopkg.in/resty.v1"
@@ -11,6 +12,11 @@ import (
 // Client represents the client state for the API.
 type Client struct {
 	RestyClient *resty.Client
+
+	// For preventing concurrent policy_channel updates
+	mutex *sync.Mutex
+	// Indicates whether or not to sequentialize policy_channel updates
+	seqPolicyChannelUpdates bool
 }
 
 // InfraClient represents the client state for the Infrastructure API
@@ -51,6 +57,9 @@ type Config struct {
 	ProxyURL  string
 	Debug     bool
 	TLSConfig *tls.Config
+
+	// Indicates whether to force sequential execution of policy_channel updates
+	SequentializePolicyChannelUpdates bool
 }
 
 // New returns a new Client for the specified apiKey.
@@ -78,7 +87,9 @@ func New(config Config) Client {
 	}
 
 	c := Client{
-		RestyClient: r,
+		RestyClient:             r,
+		seqPolicyChannelUpdates: config.SequentializePolicyChannelUpdates,
+		mutex:                   &sync.Mutex{},
 	}
 
 	return c


### PR DESCRIPTION
There is a known issue of parallelized policy_channel updates failing
when separate requests try to mutate the same channel. New Relic has
confirmed this happens because an update to the policy_channel link is
actually a mutation of the channel itself which includes a list of
policies. That list is not locked, so parallelized requests stomp
down on each other, leading to errors when using infrastructure
management tools, like Terraform, that fire requests in close
succession.