### PR TITLE
Fix Infrastructure API Pagination

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -117,10 +117,12 @@ func (c *Client) Do(method string, path string, body interface{}, response inter
 		}
 	}
 
-	if nextPath == "" {
+	apiResponseBody := apiResponse.Body()
+
+	if nextPath == "" && apiResponseBody != nil && len(apiResponseBody) > 0  {
 		linksResponse := LinksResponse{}
 
-		err = json.Unmarshal(apiResponse.Body(), &linksResponse)
+		err = json.Unmarshal(apiResponseBody, &linksResponse)
 		if err != nil {
 			return "", err
 		}

--- a/api/client.go
+++ b/api/client.go
@@ -117,15 +117,17 @@ func (c *Client) Do(method string, path string, body interface{}, response inter
 		}
 	}
 
-	infraResponse := InfraResponse{}
+	if nextPath == "" {
+		linksResponse := LinksResponse{}
 
-	err = json.Unmarshal(apiResponse.Body(), &infraResponse)
-	if err != nil {
-		return "", err
-	}
+		err = json.Unmarshal(apiResponse.Body(), &linksResponse)
+		if err != nil {
+			return "", err
+		}
 
-	if infraResponse.Links.Next != "" {
-		nextPath = infraResponse.Links.Next
+		if linksResponse.Links.Next != "" {
+			nextPath = linksResponse.Links.Next
+		}
 	}
 
 	statusClass := apiResponse.StatusCode() / 100 % 10

--- a/api/client.go
+++ b/api/client.go
@@ -119,7 +119,7 @@ func (c *Client) Do(method string, path string, body interface{}, response inter
 
 	apiResponseBody := apiResponse.Body()
 
-	if nextPath == "" && apiResponseBody != nil && len(apiResponseBody) > 0  {
+	if nextPath == "" && apiResponseBody != nil && len(apiResponseBody) > 0 {
 		linksResponse := LinksResponse{}
 
 		err = json.Unmarshal(apiResponseBody, &linksResponse)

--- a/api/client.go
+++ b/api/client.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/tls"
 	"fmt"
+	"encoding/json"
 
 	"github.com/tomnomnom/linkheader"
 	resty "gopkg.in/resty.v1"
@@ -106,6 +107,7 @@ func (c *Client) Do(method string, path string, body interface{}, response inter
 
 	nextPath := ""
 	header := apiResponse.Header().Get("Link")
+
 	if header != "" {
 		links := linkheader.Parse(header)
 
@@ -113,6 +115,17 @@ func (c *Client) Do(method string, path string, body interface{}, response inter
 			nextPath = link.URL
 			break
 		}
+	}
+
+	infraResponse := InfraResponse{}
+
+	err = json.Unmarshal(apiResponse.Body(), &infraResponse)
+	if err != nil {
+		return "", err
+	}
+
+	if infraResponse.Links.Next != "" {
+		nextPath = infraResponse.Links.Next
 	}
 
 	statusClass := apiResponse.StatusCode() / 100 % 10

--- a/api/types.go
+++ b/api/types.go
@@ -363,10 +363,12 @@ type AlertInfraCondition struct {
 	Critical            *AlertInfraThreshold `json:"critical_threshold,omitempty"`
 }
 
+// LinksResponse represents a response that contains links in the json
 type LinksResponse struct {
 	Links Links `json:"links"`
 }
 
+// Links represents a response that has next within the links value of the json
 type Links struct {
 	Next string `json:"next"`
 }

--- a/api/types.go
+++ b/api/types.go
@@ -363,7 +363,7 @@ type AlertInfraCondition struct {
 	Critical            *AlertInfraThreshold `json:"critical_threshold,omitempty"`
 }
 
-type InfraResponse struct {
+type LinksResponse struct {
 	Links Links `json:"links"`
 }
 

--- a/api/types.go
+++ b/api/types.go
@@ -123,8 +123,33 @@ type AlertChannel struct {
 	ID            int                    `json:"id,omitempty"`
 	Name          string                 `json:"name,omitempty"`
 	Type          string                 `json:"type,omitempty"`
-	Configuration map[string]interface{} `json:"configuration,omitempty"`
+	Configuration AlertChannelConfiguration `json:"configuration,omitempty"`
 	Links         AlertChannelLinks      `json:"links,omitempty"`
+}
+
+// AlertChannelConfiguration represents a Configuration type within AlertChannels
+type AlertChannelConfiguration struct {
+	Recipients string`json:"recipients,omitempty"`
+	IncludeJSONAttachment string `json:"include_json_attachment,omitempty"`
+	AuthToken string`json:"auth_token,omitempty"`
+	RoomID string`json:"room_id,omitempty"`
+	ApiKey string`json:"api_key,omitempty"`
+	Teams string`json:"teams,omitempty"`
+	Tags string`json:"tags,omitempty"`
+	Url string`json:"url,omitempty"`
+	Channel string`json:"channel,omitempty"`
+	Subdomain string`json:"subdomain,omitempty"`
+	Token string`json:"token,omitempty"`
+	Room string`json:"room,omitempty"`
+	Key string`json:"key,omitempty"`
+	RouteKey string`json:"route_key,omitempty"`
+	ServiceKey string`json:"service_key,omitempty"`
+	BaseUrl string`json:"base_url,omitempty"`
+	AuthUsername string`json:"auth_username,omitempty"`
+	AuthPassword string`json:"auth_password,omitempty"`
+	PayloadType string`json:"payload_type,omitempty"`
+	Payload map[string]interface{} `json:"payload,omitempty"`
+	Headers map[string]interface{} `json:"headers,omitempty"`
 }
 
 // ApplicationSummary represents performance information about a New Relic application.

--- a/api/types.go
+++ b/api/types.go
@@ -362,3 +362,11 @@ type AlertInfraCondition struct {
 	Warning             *AlertInfraThreshold `json:"warning_threshold,omitempty"`
 	Critical            *AlertInfraThreshold `json:"critical_threshold,omitempty"`
 }
+
+type InfraResponse struct {
+	Links Links `json:"links"`
+}
+
+type Links struct {
+	Next string `json:"next"`
+}

--- a/cmd/alert_infra_conditions.go
+++ b/cmd/alert_infra_conditions.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/imdario/mergo"
 	"github.com/spf13/cobra"
-	"fmt"
 )
 
 func makeAlertInfraConditionsCmd(dst cobra.Command) *cobra.Command {
@@ -38,8 +37,6 @@ var getAlertInfraConditionsCmd = makeAlertInfraConditionsCmd(cobra.Command{
 		if err != nil {
 			return err
 		}
-
-		fmt.Printf("Condition: %s", condition)
 
 		return outputJSON(cmd.OutOrStdout(), condition)
 	},

--- a/cmd/alert_infra_conditions.go
+++ b/cmd/alert_infra_conditions.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"github.com/imdario/mergo"
+	"github.com/spf13/cobra"
+	"fmt"
+)
+
+func makeAlertInfraConditionsCmd(dst cobra.Command) *cobra.Command {
+	src := cobra.Command{
+		Use:     "infra-conditions",
+		Aliases: []string{"infra-condition", "infra-cond"},
+	}
+
+	if err := mergo.Merge(&dst, src); err != nil {
+		panic(err)
+	}
+
+	return &dst
+}
+
+var getAlertInfraConditionsCmd = makeAlertInfraConditionsCmd(cobra.Command{
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := newInfraClient(cmd)
+		if err != nil {
+			return err
+		}
+		policyID, err := cmd.Flags().GetInt("policy-id")
+		if err != nil {
+			return err
+		}
+		id, err := cmd.Flags().GetInt("id")
+		if err != nil {
+			return err
+		}
+		condition, err := client.GetAlertInfraCondition(policyID, id)
+
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Condition: %s", condition)
+
+		return outputJSON(cmd.OutOrStdout(), condition)
+	},
+})
+
+func init() {
+	getCmd.AddCommand(getAlertInfraConditionsCmd)
+	getAlertInfraConditionsCmd.Flags().IntP("policy-id", "", 0, "ID of policy for which to get conditions")
+	getAlertInfraConditionsCmd.Flags().IntP("id", "", 0, "ID of the condition")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,3 +85,18 @@ func newAPIClient(cmd *cobra.Command) (api.Client, error) {
 
 	return client, nil
 }
+
+func newInfraClient(cmd *cobra.Command) (api.InfraClient, error) {
+	apiKey := viper.GetString("api-key")
+	baseURL := viper.GetString("api-url")
+
+	config := api.Config{
+		APIKey:  apiKey,
+		BaseURL: baseURL,
+		Debug:   debug,
+	}
+
+	client := api.NewInfraClient(config)
+
+	return client, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,18 +6,14 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect
-	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/paultyng/go-newrelic v3.1.0+incompatible // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.3
-	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 	golang.org/x/net v0.0.0-20190225175257-fe579d43d832 // indirect
 	golang.org/x/sys v0.0.0-20190302045720-b6889370fb10 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/resty.v1 v1.12.0 // indirect
 	gopkg.in/resty.v1 v1.12.0
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
+github.com/paultyng/go-newrelic v3.1.0+incompatible h1:Rk4tqa9X79e8mII/Wb2LkhTRdkr7N+YtaGtMY5IxdwE=
+github.com/paultyng/go-newrelic v3.1.0+incompatible/go.mod h1:6qjEGgk2sMkCb981StHKqGU65WZqOrLtxX6LZwRAyZo=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
NewRelic's Infrastructure API includes the link to the next set of results for an API call in the response of the API call itself as follows as defined here: [New Relic Infrastructure API Documentation (Get Condition List)](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/infrastructure-alert-conditions/rest-api-calls-new-relic-infrastructure-alerts#get-condition-list)

Currently there is a bug that uses the Infrastructure API where if you have more than 50 of those object types created, it will not be able to locate any of the objects that come after the first 50 results that are returned from the API.

The code has been updated to try to lookup the nextPath from the body if we were not able to find one in the header of the response.

