### PR TITLE
add violation_close_timer support for infra conditions

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -359,6 +359,7 @@ type AlertInfraCondition struct {
 	Where               string               `json:"where_clause,omitempty"`
 	ProcessWhere        string               `json:"process_where_clause,omitempty"`
 	IntegrationProvider string               `json:"integration_provider,omitempty"`
+	ViolationCloseTimer *int                 `json:"violation_close_timer,omitempty"`
 	Warning             *AlertInfraThreshold `json:"warning_threshold,omitempty"`
 	Critical            *AlertInfraThreshold `json:"critical_threshold,omitempty"`
 }


### PR DESCRIPTION
This functionality isn't documented yet in the public APIs but will be supported in the next day or two.  

Adds support for an optional `violation_close_timer` which specifies the number of hours a violation created from an infra condition will remain open before auto-closing and then re-opening (if it is still in violation).  If it closes before the `violation_close_timer` has been reached, then no behavior will change.

There are 3 possible values here:
  * `nil` - default to the `violation_close_timer` default as specified by New Relic
  * `0` - disable the violation auto-closing behavior
  * `> 0` - number of hours to to wait before auto-closing a violation if it is still marked as open;  the UI will have the following options - `0`, `1`, `2`, `4`, `8`, `12`, `24`, `48`, `72`... not sure how best to limit to these options in this client