### PR TITLE
Move version to it's own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ make test
 
 ### Releasing
 
-When cutting a new release, remember to update the `Version` in [api/client.go](api/client.go) to match the new tag.
+When cutting a new release, remember to update the `Version` in [api/version.go](api/version.go) to match the new tag.
 
 ## License
 [Apache-2.0](LICENSE)

--- a/api/client.go
+++ b/api/client.go
@@ -10,9 +10,6 @@ import (
 	resty "github.com/go-resty/resty/v2"
 )
 
-// Version of this library
-const Version string = "4.5.0"
-
 // Client represents the client state for the API.
 type Client struct {
 	RestyClient *resty.Client

--- a/api/version.go
+++ b/api/version.go
@@ -1,0 +1,4 @@
+package api
+
+// Version of this library
+const Version string = "4.6.0"


### PR DESCRIPTION
Make version bumps not mess with client.go history for no reason.

Once merged, we should tag v4.6.0