### PR TITLE
add support for dashboard widget thresholds

### DIFF
--- a/api/dashboards_test.go
+++ b/api/dashboards_test.go
@@ -166,7 +166,7 @@ func TestCreateDashboardCondition(t *testing.T) {
 	dashboardWidgetPresentation := DashboardWidgetPresentation{
 		Title: "95th Percentile Load Time (ms)",
 		Notes: "",
-		Threshold: DashboardWidgetThreshold{
+		Threshold: &DashboardWidgetThreshold{
 			Red:    100,
 			Yellow: 50,
 		},

--- a/api/dashboards_test.go
+++ b/api/dashboards_test.go
@@ -81,6 +81,10 @@ func TestGetDashboard(t *testing.T) {
 						"height": 1,
 						"row": 1,
 						"column": 1
+					  },
+					  "threshold": {
+						"red": 100,
+						"yellow": 50
 					  }
 					}
 				  ]
@@ -140,6 +144,10 @@ func TestCreateDashboardCondition(t *testing.T) {
 						"height": 1,
 						"row": 1,
 						"column": 1
+					  },
+					  "threshold": {
+						"red": 100,
+						"yellow": 50
 					  }
 					}
 				  ]
@@ -158,6 +166,10 @@ func TestCreateDashboardCondition(t *testing.T) {
 	dashboardWidgetPresentation := DashboardWidgetPresentation{
 		Title: "95th Percentile Load Time (ms)",
 		Notes: "",
+		Threshold: DashboardWidgetThreshold{
+			Red:    100,
+			Yellow: 50,
+		},
 	}
 
 	dashboardWidgetData := []DashboardWidgetData{
@@ -256,6 +268,10 @@ func TestCreateDashboardWithFilter(t *testing.T) {
 						"height": 1,
 						"row": 1,
 						"column": 1
+					  },
+					  "threshold": {
+						"red": 100,
+						"yellow": 50
 					  }
 					}
 				  ]

--- a/api/types.go
+++ b/api/types.go
@@ -311,9 +311,9 @@ type DashboardWidgetData struct {
 
 // DashboardWidgetPresentation represents the visual presentation of a dashboard widget.
 type DashboardWidgetPresentation struct {
-	Title     string                   `json:"title,omitempty"`
-	Notes     string                   `json:"notes,omitempty"`
-	Threshold DashboardWidgetThreshold `json:"threshold,omitempty"`
+	Title     string                    `json:"title,omitempty"`
+	Notes     string                    `json:"notes,omitempty"`
+	Threshold *DashboardWidgetThreshold `json:"threshold,omitempty"`
 }
 
 // DashboardWidgetThreshold represents the threshold configuration of a dashboard widget.

--- a/api/types.go
+++ b/api/types.go
@@ -309,10 +309,17 @@ type DashboardWidgetData struct {
 	NRQL string `json:"nrql,omitempty"`
 }
 
-// DashboardWidgetPresentation representations the visual presentation of a dashboard widget
+// DashboardWidgetPresentation represents the visual presentation of a dashboard widget.
 type DashboardWidgetPresentation struct {
-	Title string `json:"title,omitempty"`
-	Notes string `json:"notes,omitempty"`
+	Title     string                   `json:"title,omitempty"`
+	Notes     string                   `json:"notes,omitempty"`
+	Threshold DashboardWidgetThreshold `json:"threshold,omitempty"`
+}
+
+// DashboardWidgetThreshold represents the threshold configuration of a dashboard widget.
+type DashboardWidgetThreshold struct {
+	Red    float64 `json:"red,omitempty"`
+	Yellow float64 `json:"yellow,omitempty"`
 }
 
 // DashboardWidgetLayout represents the layout of a widget in a dashboard.


### PR DESCRIPTION
This PR provides support for the `thresholds` field in the dashboard resource. 