### PR TITLE
always return ErrNotFound for upstream 404s

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -163,10 +163,15 @@ func (c *Client) Do(method string, path string, body interface{}, response inter
 		}
 	}
 
-	statusClass := apiResponse.StatusCode() / 100 % 10
+	statusCode := apiResponse.StatusCode()
+	statusClass := statusCode / 100 % 10
 
 	if statusClass == 2 {
 		return nextPath, nil
+	}
+
+	if statusCode == 404 {
+		return "", ErrNotFound
 	}
 
 	rawError := apiResponse.Error()

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -67,7 +67,18 @@ func TestClientDoPaging(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestErrNotFound(t *testing.T) {
+	cli := newTestAPIClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	_, err := cli.Do("GET", "/path", nil, nil)
+
+	if err != ErrNotFound {
+		t.Fatal(err)
+	}
 }
 
 func newTestAPIClient(handler http.Handler) *Client {


### PR DESCRIPTION
This PR will return `ErrNotFound` for any API request that returns a 404.  This normalizes the response from the client to make things more predictable downstream.