### PR TITLE
add ViolationCloseTimer field to NrqlAlertCondition type

### DIFF
--- a/api/alert_nrql_conditions_test.go
+++ b/api/alert_nrql_conditions_test.go
@@ -20,6 +20,7 @@ func TestQueryAlertNrqlConditions(t *testing.T) {
 			      "name": "NRQL Condition",
 			      "runbook_url": "https://example.com/runbook.md",
 			      "enabled": true,
+                  "violation_time_limit_seconds": 3600,
 			      "terms": [
 			        {
 			          "duration": "10",
@@ -65,6 +66,7 @@ func TestGetAlertNrqlCondition(t *testing.T) {
 			      "name": "NRQL Condition",
 			      "runbook_url": "https://example.com/runbook.md",
 			      "enabled": true,
+                  "violation_time_limit_seconds": 3600,
 			      "terms": [
 			        {
 			          "duration": "10",
@@ -110,6 +112,7 @@ func TestListAlertNrqlConditions(t *testing.T) {
 			      "id": 12345,
 			      "name": "NRQL Condition",
 			      "runbook_url": "https://example.com/runbook.md",
+                  "violation_time_limit_seconds": 3600,
 			      "enabled": true,
 			      "terms": [
 			        {
@@ -155,6 +158,7 @@ func TestCreateAlertNrqlCondition(t *testing.T) {
 			      "id": 12345,
 			      "name": "NRQL Condition",
 			      "runbook_url": "https://example.com/runbook.md",
+                  "violation_time_limit_seconds": 3600,
 			      "enabled": true,
 			      "terms": [
 			        {
@@ -235,6 +239,7 @@ func TestCreateAlertNrqlStaticCondition(t *testing.T) {
                   "type": "static",
 			      "name": "NRQL Condition",
 			      "runbook_url": "https://example.com/runbook.md",
+                  "violation_time_limit_seconds": 3600,
 			      "enabled": true,
 			      "terms": [
 			        {
@@ -319,6 +324,7 @@ func TestCreateAlertNrqlBaselineCondition(t *testing.T) {
                   "type": "baseline",
 			      "name": "NRQL Condition",
 			      "runbook_url": "https://example.com/runbook.md",
+                  "violation_time_limit_seconds": 3600,
 			      "enabled": true,
 			      "terms": [
 			        {
@@ -409,6 +415,7 @@ func TestCreateAlertNrqlOutlierCondition(t *testing.T) {
                   "type": "outlier",
 			      "name": "NRQL Condition",
 			      "runbook_url": "https://example.com/runbook.md",
+                  "violation_time_limit_seconds": 3600,
 			      "enabled": true,
 			      "terms": [
 			        {
@@ -493,6 +500,7 @@ func TestUpdateAlertNrqlCondition(t *testing.T) {
 			      "id": 12345,
 			      "name": "NRQL Condition",
 			      "runbook_url": "https://example.com/runbook.md",
+                  "violation_time_limit_seconds": 3600,
 			      "enabled": true,
 			      "terms": [
 			        {

--- a/api/types.go
+++ b/api/types.go
@@ -72,17 +72,18 @@ type AlertNrqlQuery struct {
 
 // AlertNrqlCondition represents a New Relic NRQL Alert condition.
 type AlertNrqlCondition struct {
-	PolicyID       int                  `json:"-"`
-	ID             int                  `json:"id,omitempty"`
-	Type           string               `json:"type,omitempty"`
-	Name           string               `json:"name,omitempty"`
-	Enabled        bool                 `json:"enabled"`
-	RunbookURL     string               `json:"runbook_url,omitempty"`
-	Terms          []AlertConditionTerm `json:"terms,omitempty"`
-	ValueFunction  string               `json:"value_function,omitempty"`
-	ExpectedGroups int                  `json:"expected_groups,omitempty"`
-	IgnoreOverlap  bool                 `json:"ignore_overlap,omitempty"`
-	Nrql           AlertNrqlQuery       `json:"nrql,omitempty"`
+	PolicyID            int                  `json:"-"`
+	ID                  int                  `json:"id,omitempty"`
+	Type                string               `json:"type,omitempty"`
+	Name                string               `json:"name,omitempty"`
+	Enabled             bool                 `json:"enabled"`
+	RunbookURL          string               `json:"runbook_url,omitempty"`
+	Terms               []AlertConditionTerm `json:"terms,omitempty"`
+	ValueFunction       string               `json:"value_function,omitempty"`
+	ExpectedGroups      int                  `json:"expected_groups,omitempty"`
+	IgnoreOverlap       bool                 `json:"ignore_overlap,omitempty"`
+	Nrql                AlertNrqlQuery       `json:"nrql,omitempty"`
+	ViolationCloseTimer int                  `json:"violation_time_limit_seconds,omitempty"`
 }
 
 // AlertPlugin represents a plugin to use with a Plugin alert condition.


### PR DESCRIPTION
This PR adds `ViolationCloseTimer` for NRQL Alert Conditions to reflect changes to the API in order to support terraform-providers/terraform-provider-newrelic#157.

Limitations:
- Does not modify `cmd/nrql_alert_conditions.go` to use ViolationCloseTimer, as there doesn't appear to be any current means to update NRQL alert conditions through the cli.

