### PR TITLE
fix: parse floats correctly when missing integer digits

### DIFF
--- a/api/alert_conditions_test.go
+++ b/api/alert_conditions_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestListAlertConditions(t *testing.T) {
+	c := newTestAPIClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`
+			{
+				"conditions": [
+					{
+						"id": 1234,
+						"type": "browser_metric",
+						"name": "End User Apdex (Low)",
+						"enabled": false,
+						"entities": ["126408", "127809"],
+						"metric": "end_user_apdex",
+						"condition_scope": "application",
+						"terms": [{
+							"duration": "120",
+							"operator": "below",
+							"priority": "critical",
+							"threshold": ".9",
+							"time_function": "all"
+						}]
+					}
+				]
+			}
+			`))
+	}))
+
+	policyID := 123
+
+	alertConditions, err := c.queryAlertConditions(policyID)
+	if err != nil {
+		t.Log(err)
+		t.Fatal("GetAlertCondition error")
+	}
+	if alertConditions == nil {
+		t.Log(err)
+		t.Fatal("GetAlertCondition error")
+	}
+}

--- a/api/types.go
+++ b/api/types.go
@@ -1,6 +1,10 @@
 package api
 
-import "errors"
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+)
 
 var (
 	// ErrNotFound is returned when the resource was not found in New Relic.
@@ -45,9 +49,32 @@ type AlertConditionTerm struct {
 	TimeFunction string  `json:"time_function,omitempty"`
 }
 
+func (t *AlertConditionTerm) UnmarshalJSON(data []byte) error {
+	type Alias AlertConditionTerm
+	aux := &struct {
+		Duration     int    `json:"duration,string,omitempty"`
+		Operator     string `json:"operator,omitempty"`
+		Priority     string `json:"priority,omitempty"`
+		Threshold    string `json:"threshold"`
+		TimeFunction string `json:"time_function,omitempty"`
+	}{}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	threshold, err := strconv.ParseFloat(aux.Threshold, 64)
+	if err != nil {
+		return err
+	}
+
+	t.Threshold = threshold
+
+	return nil
+}
+
 // AlertCondition represents a New Relic alert condition.
 // TODO: custom unmarshal entities to ints?
-// TODO: handle unmarshaling .75 for float (not just 0.75)
 type AlertCondition struct {
 	PolicyID            int                       `json:"-"`
 	ID                  int                       `json:"id,omitempty"`

--- a/api/types.go
+++ b/api/types.go
@@ -49,8 +49,9 @@ type AlertConditionTerm struct {
 	TimeFunction string  `json:"time_function,omitempty"`
 }
 
+// UnmarshalJSON implements custom json unmarshalling for the AlertConditionTerm type
 func (t *AlertConditionTerm) UnmarshalJSON(data []byte) error {
-	type Alias AlertConditionTerm
+	type alias AlertConditionTerm
 	aux := &struct {
 		Duration     int    `json:"duration,string,omitempty"`
 		Operator     string `json:"operator,omitempty"`


### PR DESCRIPTION
This PR adds custom unmarshaling to handle float strings missing a leading zero (e.g. ".9" instead of "0.9").  The issue being fixed is demonstrated in the go playground [here](https://play.golang.org/p/D4sfo55bzIY).

It also adds test coverage for the `alert_conditions` resource.