### PR TITLE
Adding support for Smart Host Not Reporting functionality

### DIFF
--- a/api/alert_infra_conditions_test.go
+++ b/api/alert_infra_conditions_test.go
@@ -516,7 +516,7 @@ func TestCreateAlertInfraConditionHNRWithNoTriggerOnShutdown(t *testing.T) {
 						  "and": [
 							{
 							  "is": {
-								"agentName": "Infrastructure"
+								"agentName": "Infra"
 							  }
 							}
 						  ]

--- a/api/types.go
+++ b/api/types.go
@@ -416,6 +416,7 @@ type AlertInfraThreshold struct {
 	Value    int    `json:"value,omitempty"`
 	Duration int    `json:"duration_minutes,omitempty"`
 	Function string `json:"time_function,omitempty"`
+	NoTriggerOn []string `json:"no_trigger_on,omitempty"`
 }
 
 // AlertInfraCondition represents a New Relic Infra Alert condition.

--- a/api/version.go
+++ b/api/version.go
@@ -1,4 +1,4 @@
 package api
 
 // Version of this library
-const Version string = "4.10.0"
+const Version string = "4.11.0"

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,7 @@ github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2 h1:VUFqw5KcqRf7i70GOzW7N+Q7+gxVBkSSqiXB12+JQ4M=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/spf13/viper v1.6.1 h1:VPZzIkznI1YhVMRi6vNFLHSwhnhReBfgTxIPccpfdZk=
 github.com/spf13/viper v1.6.1/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
@@ -171,6 +172,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0 h1:CuXP0Pjfw9rOuY6EP+UvtNvt5DSqHpIxILZKT/quCZI=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=


### PR DESCRIPTION
Updated version

New functionality will give the user the option to not fire an HNR alert on a clean shutdown.