### PR TITLE
feat: allow infra alert threshold values to be of type float64

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -413,9 +413,9 @@ type Deployment struct {
 
 // AlertInfraThreshold represents an Infra alerting condition
 type AlertInfraThreshold struct {
-	Value    int    `json:"value,omitempty"`
-	Duration int    `json:"duration_minutes,omitempty"`
-	Function string `json:"time_function,omitempty"`
+	Value       float64  `json:"value,omitempty"`
+	Duration    int      `json:"duration_minutes,omitempty"`
+	Function    string   `json:"time_function,omitempty"`
 	NoTriggerOn []string `json:"no_trigger_on,omitempty"`
 }
 


### PR DESCRIPTION
This change facilitates resolving an [issue](https://github.com/terraform-providers/terraform-provider-newrelic/issues/291) in the New Relic Terraform Provider.